### PR TITLE
Force ArXiv URLs to use SSL

### DIFF
--- a/lib/arxiv.rb
+++ b/lib/arxiv.rb
@@ -19,8 +19,8 @@ module Arxiv
 
   # In 2007, the ArXiv API changed document ID formats:
   #
-  #    http://arxiv.org/abs/math/0510097v1  (legacy)
-  #    http://arxiv.org/abs/1202.0819v1     (current)
+  #    https://arxiv.org/abs/math/0510097v1  (legacy)
+  #    https://arxiv.org/abs/1202.0819v1     (current)
   #
   # These constants help us deal with both use cases.
   #
@@ -45,8 +45,6 @@ module Arxiv
     manuscript
   end
 
-  private
-
   def self.parse_arxiv_identifier(identifier)
     if valid_id?(identifier)
       identifier
@@ -57,16 +55,20 @@ module Arxiv
       identifier # probably an error
     end
   end
+  private_class_method :parse_arxiv_identifier
 
   def self.valid_id?(identifier)
     identifier =~ ID_FORMAT || identifier =~ LEGACY_ID_FORMAT
   end
+  private_class_method :valid_id?
 
   def self.valid_url?(identifier)
     identifier =~ LEGACY_URL_FORMAT || identifier =~ CURRENT_URL_FORMAT
   end
+  private_class_method :valid_url?
 
   def self.legacy_url?(identifier)
     identifier =~ LEGACY_URL_FORMAT
   end
+  private_class_method :legacy_url?
 end

--- a/lib/arxiv/models/manuscript.rb
+++ b/lib/arxiv/models/manuscript.rb
@@ -3,7 +3,7 @@ module Arxiv
     include HappyMapper
 
     tag 'entry'
-    element :arxiv_url, String, tag: 'id'
+    element :arxiv_url, StringScrubber, tag: 'id', parser: :force_ssl_url
     element :created_at, DateTime, tag: 'published'
     element :updated_at, DateTime, tag: 'updated'
     element :title, StringScrubber, parser: :scrub

--- a/lib/arxiv/string_scrubber.rb
+++ b/lib/arxiv/string_scrubber.rb
@@ -1,7 +1,23 @@
 module Arxiv
   class StringScrubber
-     def self.scrub(string)
+    def self.scrub(string)
       string.gsub("\n", ' ').strip.squeeze(" ")
+    end
+
+    # On approximately Oct 2016, ArXiv seems to have converted their entire
+    # site to use SSL. Old HTTP links, still work by redirecting to HTTPS.
+    #
+    # Unfortunately, this change is not yet reflected in their API responses
+    # (e.g. their API still returns a non-SSL URL). Thus, if you try to use
+    # this URL it will redirect to the new SSL URL. This can create problems
+    # if the client is not expecting redirects.
+    #
+    # Hopefully they will update their API. Until then, this little method
+    # forces `url` to use HTTPS rather than HTTP. If `url` is already HTTPS,
+    # it will happily return `url` unaltered.
+    #
+    def self.force_ssl_url(url)
+      url.sub(/^http:/, "https:")
     end
   end
 end

--- a/lib/arxiv/version.rb
+++ b/lib/arxiv/version.rb
@@ -1,3 +1,3 @@
 module Arxiv
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/spec/arxiv/models/manuscript_spec.rb
+++ b/spec/arxiv/models/manuscript_spec.rb
@@ -9,7 +9,7 @@ module Arxiv
 
     describe "arxiv_url" do
       it "should fetch the link to the manuscript's page on arXiv" do
-        expect(@manuscript.arxiv_url).to eql("http://arxiv.org/abs/1202.0819v1")
+        expect(@manuscript.arxiv_url).to eql("https://arxiv.org/abs/1202.0819v1")
       end
     end
 


### PR DESCRIPTION
For explaination of changes, see this [code comment for `StringScrubber.force_ssl_url`](https://github.com/scholastica/arxiv/pull/3/files#diff-63c5da41146b42408d7f0fdea0fbfa4dR7).
