### PR TITLE
Split author names into first and last

### DIFF
--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   # specify any dependencies here; for example:
   s.add_runtime_dependency "happymapper", '~> 0.4', '>= 0.4.1'
   s.add_runtime_dependency "nokogiri",    '~> 1.6', '>= 1.6.6.2'
+  s.add_runtime_dependency "full-name-splitter", '~> 0.1.2'
 
   s.add_development_dependency "rspec", '~> 3.3', '>= 3.3.0'
   s.add_development_dependency "pry",   '~> 0.10.2'

--- a/lib/arxiv.rb
+++ b/lib/arxiv.rb
@@ -1,6 +1,7 @@
 require 'open-uri'
 require 'nokogiri'
 require 'happymapper'
+require 'full-name-splitter'
 
 require 'arxiv/version'
 require 'arxiv/string_scrubber'

--- a/lib/arxiv/models/author.rb
+++ b/lib/arxiv/models/author.rb
@@ -3,5 +3,13 @@ module Arxiv
     include HappyMapper
     element :name, StringScrubber, parser: :scrub
     has_many :affiliations, StringScrubber, parser: :scrub, tag: 'affiliation'
+
+    def first_name
+      FullNameSplitter.split(name).first
+    end
+
+    def last_name
+      FullNameSplitter.split(name).last
+    end
   end
 end

--- a/lib/arxiv/models/author.rb
+++ b/lib/arxiv/models/author.rb
@@ -4,10 +4,22 @@ module Arxiv
     element :name, StringScrubber, parser: :scrub
     has_many :affiliations, StringScrubber, parser: :scrub, tag: 'affiliation'
 
+    # Unfortunately, the ArXiv API does not provide separate attributes for
+    # `author.first_name` and `author.last_name`; it only provides a single
+    # `author.name` attribute.
+    #
+    # Yet most standards within academic publishing (e.g. JATS XML) prefer to
+    # differentiate first name and last name of authors. To support that
+    # expectation, we've split the name value (leveraging a third-party gem).
+    # Ideally, ArXiv would provide this data directly. But until then, this
+    # solution should be suitable.
+    #
     def first_name
       FullNameSplitter.split(name).first
     end
 
+    # See code comment for `first_name`.
+    #
     def last_name
       FullNameSplitter.split(name).last
     end

--- a/lib/arxiv/version.rb
+++ b/lib/arxiv/version.rb
@@ -1,3 +1,3 @@
 module Arxiv
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/arxiv/models/author_spec.rb
+++ b/spec/arxiv/models/author_spec.rb
@@ -10,6 +10,18 @@ module Arxiv
       end
     end
 
+    describe "first_name" do
+      it "should return the author's first name" do
+        expect(@author.first_name).to eql("Michael T.")
+      end
+    end
+
+    describe "last_name" do
+      it "should return the author's last name" do
+        expect(@author.last_name).to eql("Murphy")
+      end
+    end
+
     describe "affiliations" do
       it "should return an array of the author's affiliations" do
         expect(@author.affiliations).to include("Swinburne University of Technology")


### PR DESCRIPTION
Split `author.name` into `author.first_name` and `author.last_name` by leveraging [full-name-splitter](https://github.com/pahanix/full-name-splitter) gem. This change is additive and non-breaking.

This change helps conform to industry standards such as JATS XML. 