### PR TITLE
Get tests passing/green (toward a working CI)

### DIFF
--- a/lib/arxiv.rb
+++ b/lib/arxiv.rb
@@ -47,7 +47,7 @@ module Arxiv
   end
 
   def self.parse_arxiv_identifier(identifier)
-    if valid_id?(identifier)
+    id = if valid_id?(identifier)
       identifier
     elsif valid_url?(identifier)
       format = legacy_url?(identifier) ? LEGACY_URL_FORMAT : CURRENT_URL_FORMAT
@@ -55,8 +55,19 @@ module Arxiv
     else
       identifier # probably an error
     end
+
+    normalize_legacy_id(id)
   end
   private_class_method :parse_arxiv_identifier
+
+  # In April 2007, arxiv dropped the subject-class suffix from legacy identifiers
+  # (e.g. `math.DG/0510097` became `math/0510097`). The website still 301-redirects
+  # the old form, but the API at /api/query?id_list=math.DG/0510097 silently returns
+  # no results. Normalize so callers can pass either form.
+  def self.normalize_legacy_id(id)
+    id.sub(/\A([^.\/]+)\.[^\/]+\//, '\1/')
+  end
+  private_class_method :normalize_legacy_id
 
   def self.valid_id?(identifier)
     identifier =~ ID_FORMAT || identifier =~ LEGACY_ID_FORMAT

--- a/spec/arxiv/arxiv_spec.rb
+++ b/spec/arxiv/arxiv_spec.rb
@@ -51,4 +51,35 @@ module Arxiv
     end
 
   end
+
+  # NOTE: This describe block tests a private method (via `.send`) which is
+  # unusual for this codebase. It's here to make the regex's behavior visible
+  # at PR-review time across the various legacy ID forms arxiv has historically
+  # used. Feel free to drop this block — the behavior is also covered indirectly
+  # by the legacy-id specs above.
+  describe "normalize_legacy_id (private)" do
+    cases = {
+      # legacy with subject class -> stripped to bare archive
+      "math.DG/0510097"         => "math/0510097",
+      "math.DG/0510097v1"       => "math/0510097v1",
+      "cond-mat.dis-nn/9912001" => "cond-mat/9912001",
+
+      # already-canonical legacy -> unchanged
+      "math/0510097"     => "math/0510097",
+      "math/0510097v1"   => "math/0510097v1",
+      "cs/0002001"       => "cs/0002001",
+      "cond-mat/9912001" => "cond-mat/9912001",
+
+      # current id format (no slash) -> unchanged
+      "1202.0819"   => "1202.0819",
+      "1202.0819v1" => "1202.0819v1",
+      "1509.06369"  => "1509.06369",
+    }
+
+    cases.each do |input, expected|
+      it "#{input.inspect} -> #{expected.inspect}" do
+        expect(Arxiv.send(:normalize_legacy_id, input)).to eql(expected)
+      end
+    end
+  end
 end

--- a/spec/arxiv/models/category_spec.rb
+++ b/spec/arxiv/models/category_spec.rb
@@ -4,7 +4,6 @@ module Arxiv
   describe Category do
     before(:all) do
       @category = Arxiv.get('1202.0819').primary_category
-      @legacy_category = Arxiv.get('math.DG/0510097v1').categories.last
     end
 
     describe "abbreviation" do
@@ -25,7 +24,9 @@ module Arxiv
       end
 
       it "should return only the abbreviation when a description cannot be found (e.g. MSC classes)"do
-        expect(@legacy_category.long_description).to eql("58D15 (Primary); 58B10 (Secondary)")
+        category = Category.new
+        category.abbreviation = "58D15 (Primary); 58B10 (Secondary)"
+        expect(category.long_description).to eql("58D15 (Primary); 58B10 (Secondary)")
       end
     end
 

--- a/spec/arxiv/models/link_spec.rb
+++ b/spec/arxiv/models/link_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Arxiv
   describe Link do
-    before(:all) { @link = Arxiv.get('1202.0819').links.last }
+    before(:all) { @link = Arxiv.get('1202.0819').links.find { |l| l.content_type == 'application/pdf' } }
 
     describe "content_type" do
       it "should fetch the link's content type" do
@@ -12,7 +12,7 @@ module Arxiv
 
     describe "url" do
       it "should fetch the link's url" do
-        expect(@link.url).to eql('http://arxiv.org/pdf/1202.0819v1')
+        expect(@link.url).to eql('https://arxiv.org/pdf/1202.0819v1')
       end
     end
 


### PR DESCRIPTION
# Get CI green

✅ tl;dr— I fixed failing tests. With some test setup and a "bug" fix.

---

Hi 👋🏻 I was looking at this gem today and noticed CI isn't passing/running.
And tests weren't passing (for me) locally either.
I spelunked around a bit and found that it's mostly an issue of upstream API drift.

# 1. PDF URL changed

**PDF link moved.** ArXiv's API added another `link` to each item in its response. So `links.last` was no longer the `.pdf`. Changing the setup in `before` in block to parse out and the PDF from the `manuscripts.links` list fixed one failing test.

# 2. HTTP->HTTPS URL

**HTTPS link URLs.** ArXiv's API now returns `links` with `https://` URLs instead of `http://` (finallly). Simple change to expected URL fixed another test.[^1]

[^1]: As a related bonus to this upstream API change, the need for `Arxiv::StringScrubber.force_ssl_url` is probably obviated and could probably be removed entirely (in a separate PR).

# 3. Category#long_description

**API removed msc_class.** ArXiv's API no longer sends [MSC classification](https://en.wikipedia.org/wiki/Mathematics_Subject_Classification) (`msc_class`) on legacy papers. So, the `Manuscript` returned no longer has a `Category` that the test is expecting. Instead, the test now sets up a `Category` without fetching one from API, and confirms the implementation of `Category#long_description` still works as expected (it falls back to `abbreviation` if `description` is blank.)

# 4. Legacy ID format

**Subject prefix support dropped.** Most of the test failures were because of this. TL;DR— test setup expects non-blank results from arxiv.org API, but were getting blank results. Then the test body had nothing to work with. Because:

1. Previously, both legacy ID formats were allowed: `math.DG/0510097` and `math/0510097`
2. Presently, the subject prefix is not allowed: `.DG` in `math.DG/0510097`.
3. The website redirects from `math.DG/0510097` to `math/0510097`.
4. But, the API doesn't redirect and returns empty search results for "`math.DG/0510097`".
5. When using the now-unsupported format, `Arxiv.get('math.DG/0510097')` raises a `ManuscriptNotFound` error.

Demonstration:

```sh
#🚫
curl -s 'https://export.arxiv.org/api/query?id_list=math.DG/0510097' | grep totalResults
#=> <opensearch:totalResults>0</opensearch:totalResults>

#✅
curl -s 'https://export.arxiv.org/api/query?id_list=math/0510097' | grep totalResults
#=> <opensearch:totalResults>1</opensearch:totalResults>

#✅
curl -s 'https://export.arxiv.org/api/query?id_list=math/0510097' | grep title
#=> <title>The differential topology of loop spaces</title>
#=> ...
```

I saw two possible resolutions:

1. Accept that `Arxiv.get` with subject prefix (`.DG`) is now invalid usage and returning `ManuscriptNotFound` error is the correct result. In which case, some tests need to be updated to reflect that.
2. Allow `Arxiv.get` with subject prefix (`.DG`) usage and then internally clean up the user input, removing the subject prefix, before calling the arxiv.org API.

IMO, 2 is a friendlier, more humane path.
([Postel's law / robustness principle](https://en.wikipedia.org/wiki/Robustness_principle))

**Important:** The one non-test behavioral change that I made in this PR is a new private class method: `Arxiv.normalize_legacy_id`.

```ruby
def self.normalize_legacy_id(id)
  id.sub(/\A([^.\/]+)\.[^\/]+\//, '\1/')
end
private_class_method :normalize_legacy_id
```

## A note about tests

I added tests for `Arxiv.normalize_legacy_id` which use `.send` to call the private class method. I don't normally write tests for private methods. Or use `.send` if I can avoide.

But, because this is my first PR in this codebase and because regular expressions are not super readable to begin with, and this one is especially symbolly… I added tests to make it easier to verify the behavior.

Variations that I tested in `spec/arxiv/arxiv_spec.rb:60`:

| Input                     | Output             |
| ------------------------- | ------------------ |
| `math.DG/0510097`         | `math/0510097`     |
| `math.DG/0510097v1`       | `math/0510097v1`   |
| `cond-mat.dis-nn/9912001` | `cond-mat/9912001` |
| `math/0510097`            | `math/0510097`     |
| `cs/0002001`              | `cs/0002001`       |
| `cond-mat/9912001`        | `cond-mat/9912001` |
| `1202.0819`               | `1202.0819`        |
| `1202.0819v1`             | `1202.0819v1`      |

Feel free to delete them if you don't want private method tests in your test suite. I'm also not at all married to the method, its name, or its implemetation. Feel free to change any of it, however you want!

Sorry this was so long.

/end
