### PR TITLE
Gemspec + Gemfile cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: ci
 on:
   push:
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in arxiv.gemspec
 gemspec
+
+group :development, :test do
+  gem "pry",   "~> 0.10.2"
+  gem "rspec", "~> 3.3", ">= 3.3.0"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in arxiv.gemspec
 gemspec

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  spec.add_runtime_dependency "happymapper", '~> 0.4', '>= 0.4.1'
-  spec.add_runtime_dependency "nokogiri",    '~> 1.6', '>= 1.6.6.2'
-  spec.add_runtime_dependency "full-name-splitter", '~> 0.1.2'
+  spec.add_dependency "happymapper", '~> 0.4', '>= 0.4.1'
+  spec.add_dependency "nokogiri",    '~> 1.6', '>= 1.6.6.2'
+  spec.add_dependency "full-name-splitter", '~> 0.1.2'
 
   spec.add_development_dependency "rspec", '~> 3.3', '>= 3.3.0'
   spec.add_development_dependency "pry",   '~> 0.10.2'

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -16,7 +16,8 @@ Gem::Specification.new do |s|
   s.licenses    = ['MIT']
 
   s.files         = `git ls-files`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.bindir        = "exe"
+  s.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
 require "arxiv/version"
 

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -1,5 +1,4 @@
-$:.push File.expand_path("../lib", __FILE__)
-require "arxiv/version"
+require_relative "lib/arxiv/version"
 
 Gem::Specification.new do |s|
   s.name        = "arxiv"

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -1,30 +1,30 @@
 require_relative "lib/arxiv/version"
 
-Gem::Specification.new do |s|
-  s.name        = "arxiv"
-  s.version     = Arxiv::VERSION
-  s.authors     = ["Scholastica"]
-  s.email       = ["coryschires@gmail.com"]
-  s.homepage    = "https://github.com/scholastica/arxiv"
-  s.metadata    = {
+Gem::Specification.new do |spec|
+  spec.name        = "arxiv"
+  spec.version     = Arxiv::VERSION
+  spec.authors     = ["Scholastica"]
+  spec.email       = ["coryschires@gmail.com"]
+  spec.homepage    = "https://github.com/scholastica/arxiv"
+  spec.metadata    = {
     "bug_tracker_uri" => "https://github.com/scholastica/arxiv/issues",
     "homepage_uri"    => "https://github.com/scholastica/arxiv",
     "source_code_uri" => "https://github.com/scholastica/arxiv"
   }
-  s.summary     = "Ruby wrapper accessing the arXiv API"
-  s.description = "Easily access arXiv article info – including authors, categories, links, etc."
-  s.licenses    = ['MIT']
+  spec.summary     = "Ruby wrapper accessing the arXiv API"
+  spec.description = "Easily access arXiv article info – including authors, categories, links, etc."
+  spec.licenses    = ['MIT']
 
-  s.files         = `git ls-files`.split("\n")
-  s.bindir        = "exe"
-  s.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  spec.files         = `git ls-files`.split("\n")
+  spec.bindir        = "exe"
+  spec.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
+  spec.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_runtime_dependency "happymapper", '~> 0.4', '>= 0.4.1'
-  s.add_runtime_dependency "nokogiri",    '~> 1.6', '>= 1.6.6.2'
-  s.add_runtime_dependency "full-name-splitter", '~> 0.1.2'
+  spec.add_runtime_dependency "happymapper", '~> 0.4', '>= 0.4.1'
+  spec.add_runtime_dependency "nokogiri",    '~> 1.6', '>= 1.6.6.2'
+  spec.add_runtime_dependency "full-name-splitter", '~> 0.1.2'
 
-  s.add_development_dependency "rspec", '~> 3.3', '>= 3.3.0'
-  s.add_development_dependency "pry",   '~> 0.10.2'
+  spec.add_development_dependency "rspec", '~> 3.3', '>= 3.3.0'
+  spec.add_development_dependency "pry",   '~> 0.10.2'
 end

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -15,9 +15,17 @@ Gem::Specification.new do |spec|
   spec.description = "Easily access arXiv article info – including authors, categories, links, etc."
   spec.licenses    = ['MIT']
 
-  spec.files         = `git ls-files`.split("\n")
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  gemspec = File.basename(__FILE__)
+  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) ||
+        f.start_with?(*%w[bin/ Gemfile .gitignore .rspec spec/ .github/ .rubocop.yml])
+    end
+  end
   spec.bindir        = "exe"
-  spec.executables   = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
+  spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   # specify any dependencies here; for example:

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.summary     = "Ruby wrapper accessing the arXiv API"
   s.description = "Easily access arXiv article info – including authors, categories, links, etc."
   s.licenses    = ['MIT']
-  s.rubyforge_project = "arxiv"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   }
   spec.summary     = "Ruby wrapper accessing the arXiv API"
   spec.description = "Easily access arXiv article info – including authors, categories, links, etc."
-  spec.licenses    = ['MIT']
+  spec.licenses    = ["MIT"]
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  spec.add_dependency "happymapper", '~> 0.4', '>= 0.4.1'
-  spec.add_dependency "nokogiri",    '~> 1.6', '>= 1.6.6.2'
-  spec.add_dependency "full-name-splitter", '~> 0.1.2'
+  spec.add_dependency "happymapper", "~> 0.4", ">= 0.4.1"
+  spec.add_dependency "nokogiri",    "~> 1.6", ">= 1.6.6.2"
+  spec.add_dependency "full-name-splitter", "~> 0.1.2"
 end

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -6,6 +6,11 @@ Gem::Specification.new do |s|
   s.authors     = ["Scholastica"]
   s.email       = ["coryschires@gmail.com"]
   s.homepage    = "https://github.com/scholastica/arxiv"
+  s.metadata    = {
+    "bug_tracker_uri" => "https://github.com/scholastica/arxiv/issues",
+    "homepage_uri"    => "https://github.com/scholastica/arxiv",
+    "source_code_uri" => "https://github.com/scholastica/arxiv"
+  }
   s.summary     = "Ruby wrapper accessing the arXiv API"
   s.description = "Easily access arXiv article info – including authors, categories, links, etc."
   s.licenses    = ['MIT']

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -24,7 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "happymapper", '~> 0.4', '>= 0.4.1'
   spec.add_dependency "nokogiri",    '~> 1.6', '>= 1.6.6.2'
   spec.add_dependency "full-name-splitter", '~> 0.1.2'
-
-  spec.add_development_dependency "rspec", '~> 3.3', '>= 3.3.0'
-  spec.add_development_dependency "pry",   '~> 0.10.2'
 end

--- a/arxiv.gemspec
+++ b/arxiv.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.licenses    = ['MIT']
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
Cosmetic gemspec + Gemfile cleanup — no behavior change. Each commit is one self-contained move, easy to review or drop individually.

## gemspec
- Drop the `# -*- encoding: utf-8 -*-` magic comment (unneeded on modern Ruby).
- `require_relative "lib/arxiv/version"` instead of `$:.push … + require`.
- Remove deprecated `rubyforge_project`.
- Remove deprecated `test_files` (ignored by modern RubyGems).
- Add `metadata` URIs: `bug_tracker_uri`, `homepage_uri`, `source_code_uri`.
- `bindir = "exe"` + executables globbed from `exe/` (empty today — preemptive, no behavior change).
- Rename the spec block var `s` → `spec`.
- `add_dependency` instead of `add_runtime_dependency` (same effect, current spelling).
- Replace the backtick `git ls-files` files list with the current `bundle gem` generator form (excludes dev/CI files from the packaged gem).
- Unify on double quotes throughout the gemspec.

## Gemfile
- Move `rspec` and `pry` out of the gemspec into a `group :development, :test`.
- `https://` rubygems source.

## CI
- Add a `pull_request` trigger so PRs get checks on their own changeset (the workflow was `push`-only, which doesn't run on PRs).

Left `changelog_uri` out of the metadata for now — there's no `CHANGELOG.md` yet, so it'd be a dead link; better added alongside one.
